### PR TITLE
Windows Browser Detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,25 +174,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-docker"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "is-wsl"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
-dependencies = [
- "is-docker",
- "once_cell",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,39 +214,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
-name = "once_cell"
-version = "1.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
 name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
-name = "open"
-version = "5.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2483562e62ea94312f3576a7aca397306df7990b8d89033e18766744377ef95"
-dependencies = [
- "is-wsl",
- "libc",
- "pathdiff",
-]
-
-[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "pathdiff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "proc-macro2"
@@ -282,10 +240,10 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "dirs",
- "open",
  "serde",
  "serde_json",
  "which",
+ "winreg",
 ]
 
 [[package]]
@@ -664,6 +622,16 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winreg"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "937f3df7948156640f46aacef17a70db0de5917bda9c92b0f751f3a955b588fc"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "winsafe"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,16 @@
+# Cargo.toml
 [package]
 name = "quick_tabs"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+# Using clap 4.5 for modern CLI argument parsing
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 dirs = "5.0"
 which = "6.0"
-open = "5.3.2"
+# Windows specific library for robust registry access
+#[cfg(target_os = "windows")]
+winreg = "0.51" 

--- a/commands/aliases.rs
+++ b/commands/aliases.rs
@@ -1,8 +1,11 @@
+// commands/aliases.rs
 use std::collections::HashMap;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{PathBuf, Path};
 use crate::commands::detect::Browser;
+use crate::commands::links::{launch_link, LaunchMode, launch_urls_simultaneously};
 use serde::{Serialize, Deserialize};
+use std::io;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AliasConfig {
@@ -10,18 +13,26 @@ pub struct AliasConfig {
 }
 
 impl AliasConfig {
-    pub fn load(path: &PathBuf) -> Self {
+    pub fn load(path: &Path) -> Self {
         if path.exists() {
-            let data = fs::read_to_string(path).unwrap_or_default();
-            serde_json::from_str(&data).unwrap_or(AliasConfig { aliases: HashMap::new() })
+            match fs::read_to_string(path) {
+                Ok(data) => serde_json::from_str(&data).unwrap_or_else(|e| {
+                    eprintln!("⚠️ Failed to parse alias config {}: {}", path.display(), e);
+                    AliasConfig { aliases: HashMap::new() }
+                }),
+                Err(e) => {
+                    eprintln!("⚠️ Failed to read alias config {}: {}", path.display(), e);
+                    AliasConfig { aliases: HashMap::new() }
+                }
+            }
         } else {
             AliasConfig { aliases: HashMap::new() }
         }
     }
 
-    pub fn save(&self, path: &PathBuf) {
-        let json = serde_json::to_string_pretty(&self).unwrap();
-        fs::write(path, json).unwrap();
+    pub fn save(&self, path: &Path) -> io::Result<()> {
+        let json = serde_json::to_string_pretty(&self)?;
+        fs::write(path, json)
     }
 
     pub fn add_alias(&mut self, tag: String, url: String) {
@@ -31,15 +42,29 @@ impl AliasConfig {
     pub fn resolve(&self, tag: &str) -> Option<String> {
         self.aliases.get(tag).cloned()
     }
-}
-impl AliasConfig {
+
     pub fn remove_alias(&mut self, tag: &str) -> bool {
         self.aliases.remove(tag).is_some()
     }
 
-    pub fn open_all(&self, browser: &Browser) {
-        for (_, url) in &self.aliases {
-            super::links::launch_link(browser, url);
+    pub fn list(&self) {
+        if self.aliases.is_empty() {
+            println!("⚠️ No aliases saved.");
+        } else {
+            println!("\n✨ Saved aliases:");
+            for (tag, url) in &self.aliases {
+                println!("  [{}] -> {}", tag, url);
+            }
         }
+    }
+    
+    pub fn open_all(&self, browser: &Browser, mode: LaunchMode) {
+        if self.aliases.is_empty() {
+            println!("⚠️ No aliases to open.");
+            return;
+        }
+
+        let urls: Vec<&str> = self.aliases.values().map(|url| url.as_str()).collect();
+        launch_urls_simultaneously(browser, &urls, mode);
     }
 }

--- a/commands/detect.rs
+++ b/commands/detect.rs
@@ -1,3 +1,4 @@
+// commands/detect.rs
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::fs;
@@ -5,6 +6,13 @@ use std::env;
 use std::process::Command;
 use serde::{Serialize, Deserialize};
 use which::which;
+
+#[cfg(target_os = "windows")]
+use winreg::enums::*;
+#[cfg(target_os = "windows")]
+use winreg::RegKey;
+
+// --- Data Structures ---
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Browser {
@@ -18,8 +26,10 @@ struct Config {
     browser: Browser,
 }
 
+// --- Public Entry Point ---
+
 pub fn run() -> Option<Browser> {
-    let config_path = get_config_path();
+    let config_path = get_app_config_path();
 
     if let Some(browser) = load_saved_browser(&config_path) {
         println!("⚡ Using saved browser: {}", browser.path.display());
@@ -27,6 +37,7 @@ pub fn run() -> Option<Browser> {
     }
 
     let mut detected = detect_all_browsers();
+    write_outputs(&detected).ok(); // Write full list to CWD
 
     let selected = match detected.len() {
         0 => {
@@ -48,41 +59,57 @@ pub fn run() -> Option<Browser> {
     selected
 }
 
-fn detect_all_browsers() -> Vec<Browser> {
-    println!("🔍 Searching for installed browsers...\n");
+// --- Detection Logic ---
 
-    let browsers = vec![
+fn detect_all_browsers() -> Vec<Browser> {
+    println!("🔍 Searching for installed browsers...");
+
+    let known_browsers = vec![
         ("Google Chrome", "chrome"),
         ("Mozilla Firefox", "firefox"),
         ("Brave", "brave"),
         ("Microsoft Edge", "msedge"),
         ("Opera", "opera"),
         ("Chromium", "chromium"),
-        ("Safari", "safari"),
     ];
 
     let mut found = vec![];
 
-    for (name, exec) in browsers {
+    // 1. Check PATH and common installation directories
+    for (name, exec) in known_browsers.iter() {
         found.extend(detect_browser(name, exec));
     }
+    
+    // 2. Check Windows Registry (most reliable method on Windows)
+    #[cfg(target_os = "windows")]
+    {
+        found.extend(probe_registry());
+    }
 
-    if !found.is_empty() {
-        println!("✨ Found {} browsers:", found.len());
-        for (i, b) in found.iter().enumerate() {
+    // Deduplicate by path
+    let mut unique_paths = std::collections::HashSet::new();
+    let unique_found: Vec<Browser> = found.into_iter()
+        .filter(|b| unique_paths.insert(b.path.clone()))
+        .collect();
+
+    if !unique_found.is_empty() {
+        println!("✨ Found {} unique browsers:", unique_found.len());
+        for (i, b) in unique_found.iter().enumerate() {
             let ver = b.version.clone().unwrap_or_else(|| "unknown".to_string());
             println!("  [{}] {} (version: {}, path: {})", i + 1, b.name, ver, b.path.display());
         }
+    } else {
+        println!("⚠️ Did not find any known browsers.");
     }
 
-    found
+    unique_found
 }
 
-fn detect_browser(name: &str, exec: &str) -> Vec<Browser> {
+fn detect_browser(name: &str, base_exec: &str) -> Vec<Browser> {
     let mut found = vec![];
+    let exec_name = get_executable_name(base_exec);
 
-    let exec_name = get_executable_name(exec);
-
+    // Check PATH
     if let Ok(path) = which(&exec_name) {
         found.push(Browser {
             name: name.to_string(),
@@ -91,6 +118,7 @@ fn detect_browser(name: &str, exec: &str) -> Vec<Browser> {
         });
     }
 
+    // Check common platform-specific paths
     for candidate in common_paths(&exec_name) {
         if candidate.exists() && !found.iter().any(|b| b.path == candidate) {
             found.push(Browser {
@@ -104,6 +132,47 @@ fn detect_browser(name: &str, exec: &str) -> Vec<Browser> {
     found
 }
 
+#[cfg(target_os = "windows")]
+fn probe_registry() -> Vec<Browser> {
+    let mut result = Vec::new();
+
+    // Paths where default browser commands are stored
+    let hives = [HKEY_LOCAL_MACHINE, HKEY_CURRENT_USER];
+    const SUBKEY: &str = "SOFTWARE\\Clients\\StartMenuInternet";
+
+    for &hive in &hives {
+        if let Ok(key) = RegKey::predef(hive).open_subkey(SUBKEY) {
+            for browser_name in key.enum_keys().flatten() {
+                let subpath = format!("{SUBKEY}\\{browser_name}");
+                if let Ok(sub) = RegKey::predef(hive).open_subkey(&subpath) {
+                    if let Ok(cmd) = sub.open_subkey("shell\\open\\command") {
+                        if let Ok(val) = cmd.get_value::<String, _>("") {
+                            // Clean up path: remove quotes and arguments
+                            let cleaned = val.split_whitespace().next().unwrap_or(&val).trim_matches('"').to_string();
+                            let path = PathBuf::from(&cleaned);
+
+                            if path.exists() {
+                                let exe_name = path.file_stem()
+                                    .map(|n| n.to_string_lossy().to_string())
+                                    .unwrap_or(browser_name.clone());
+
+                                result.push(Browser {
+                                    name: exe_name,
+                                    path,
+                                    version: get_version(&PathBuf::from(cleaned)),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    result
+}
+
+// --- Utility Functions ---
+
 fn get_executable_name(base: &str) -> String {
     if cfg!(target_os = "windows") {
         format!("{base}.exe")
@@ -113,25 +182,66 @@ fn get_executable_name(base: &str) -> String {
 }
 
 fn get_version(path: &PathBuf) -> Option<String> {
+    // Note: --version flag is highly common but not universal.
     Command::new(path)
         .arg("--version")
         .output()
         .ok()
         .and_then(|output| {
             let version_str = String::from_utf8_lossy(&output.stdout);
-            Some(version_str.trim().to_string())
+            // Typically version is the last word or first line. Clean it up.
+            Some(version_str.lines().next().unwrap_or(&version_str).trim().to_string())
         })
 }
+
+fn common_paths(exec: &str) -> Vec<PathBuf> {
+    let mut paths = vec![];
+
+    if cfg!(target_os = "windows") {
+        let pf = env::var("ProgramFiles").unwrap_or_default();
+        let pf_x86 = env::var("ProgramFiles(x86)").unwrap_or_default();
+        let local = env::var("LOCALAPPDATA").unwrap_or_default();
+        
+        let candidates = vec![
+            format!("{pf}\\Google\\Chrome\\Application\\{exec}"),
+            format!("{pf_x86}\\Google\\Chrome\\Application\\{exec}"),
+            format!("{pf}\\Mozilla Firefox\\{exec}"),
+            format!("{pf_x86}\\Microsoft\\Edge\\Application\\{exec}"),
+            format!("{pf}\\BraveSoftware\\Brave-Browser\\Application\\{exec}"),
+            format!("{local}\\Programs\\{exec}"),
+        ];
+        paths.extend(candidates.into_iter().map(PathBuf::from));
+    } else if cfg!(target_os = "macos") {
+        // macOS executable paths within .app bundles
+        let base_name = exec.replace(".exe", "");
+        paths.push(PathBuf::from(format!("/Applications/{base_name}.app/Contents/MacOS/{base_name}")));
+        // Handle common variations
+        if base_name == "chrome" {
+             paths.push(PathBuf::from("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"));
+        }
+    } else { // Linux/Unix
+        paths.push(PathBuf::from(format!("/usr/bin/{exec}")));
+        paths.push(PathBuf::from(format!("/usr/local/bin/{exec}")));
+        paths.push(PathBuf::from(format!("/snap/bin/{exec}")));
+        paths.push(PathBuf::from(format!("/opt/{exec}/{exec}")));
+    }
+
+    paths
+}
+
+// --- Interaction and Configuration Saving ---
 
 fn choose_browser_interactively(found: &mut [Browser]) -> Option<Browser> {
     println!("\nSelect a browser:");
     println!("  [M] Manual entry");
 
     print!("Enter choice [1-{} or M]: ", found.len());
-    io::stdout().flush().unwrap();
+    let _ = io::stdout().flush();
 
     let mut input = String::new();
-    io::stdin().read_line(&mut input).unwrap();
+    if io::stdin().read_line(&mut input).is_err() {
+        return None;
+    }
     let choice = input.trim();
 
     if choice.eq_ignore_ascii_case("m") {
@@ -146,17 +256,20 @@ fn choose_browser_interactively(found: &mut [Browser]) -> Option<Browser> {
         }
     }
 
-    println!("⚠️ Invalid choice. Falling back to manual entry.");
+    println!("⚠️ Invalid choice. Retrying manual entry.");
     manual_select()
 }
 
 pub fn manual_select() -> Option<Browser> {
     println!("\n🖊️ Enter full path to browser executable:");
     print!("Path: ");
-    io::stdout().flush().unwrap();
+    let _ = io::stdout().flush();
 
     let mut path = String::new();
-    io::stdin().read_line(&mut path).unwrap();
+    if io::stdin().read_line(&mut path).is_err() {
+        println!("❌ Read error.");
+        return None;
+    }
     let path = PathBuf::from(path.trim());
 
     if path.exists() {
@@ -167,47 +280,19 @@ pub fn manual_select() -> Option<Browser> {
             version: get_version(&path),
         })
     } else {
-        println!("❌ Invalid path.");
+        println!("❌ Invalid path: path does not exist.");
         None
     }
 }
 
-fn common_paths(exec: &str) -> Vec<PathBuf> {
-    let mut paths = vec![];
+// --- File Storage Handlers ---
 
-    if cfg!(target_os = "windows") {
-        let pf = env::var("ProgramFiles").unwrap_or_default();
-        let pf_x86 = env::var("ProgramFiles(x86)").unwrap_or_default();
-        let local = env::var("LOCALAPPDATA").unwrap_or_default();
-        let candidates = vec![
-            format!("{pf}\\{exec}\\Application\\{exec}"),
-            format!("{pf_x86}\\{exec}\\Application\\{exec}"),
-            format!("{local}\\Programs\\{exec}\\{exec}"),
-        ];
-        paths.extend(candidates.into_iter().map(PathBuf::from));
-    } else if cfg!(target_os = "macos") {
-        paths.push(PathBuf::from(format!("/Applications/{}.app/Contents/MacOS/{}", exec, exec)));
-        paths.push(PathBuf::from(format!("/System/Applications/{}.app/Contents/MacOS/{}", exec, exec)));
-    } else {
-        paths.push(PathBuf::from(format!("/usr/bin/{exec}")));
-        paths.push(PathBuf::from(format!("/usr/local/bin/{exec}")));
-        paths.push(PathBuf::from(format!("/snap/bin/{exec}")));
-        paths.push(PathBuf::from(format!("/opt/{exec}/{exec}")));
-    }
-
-    paths
-}
-
-fn get_config_path() -> PathBuf {
-    if cfg!(target_os = "windows") {
-        let local = env::var("LOCALAPPDATA").unwrap_or(".".to_string());
-        let folder = Path::new(&local).join("quick_tabs");
-        fs::create_dir_all(&folder).ok();
-        folder.join("config.json")
-    } else {
-        let home = env::var("HOME").unwrap_or(".".to_string());
-        Path::new(&home).join(".quick_tabs.json")
-    }
+/// Gets the application configuration path (~/.config/quick_tabs/config.json)
+fn get_app_config_path() -> PathBuf {
+    let mut config_dir = dirs::config_dir().unwrap_or_else(|| PathBuf::from("."));
+    config_dir.push("quick_tabs");
+    fs::create_dir_all(&config_dir).ok();
+    config_dir.join("browser_config.json")
 }
 
 fn load_saved_browser(config_path: &Path) -> Option<Browser> {
@@ -228,7 +313,31 @@ fn save_browser(config_path: &Path, browser: &Browser) {
         browser: browser.clone(),
     };
     if let Ok(json) = serde_json::to_string_pretty(&cfg) {
-        fs::write(config_path, json).ok();
+        if fs::write(config_path, json).is_ok() {
+            println!("💾 Saved preferred browser to config: {}", config_path.display());
+        } else {
+            eprintln!("⚠️ Could not save browser config to {}", config_path.display());
+        }
     }
-    println!("💾 Saved browser to config: {}", config_path.display());
+}
+
+/// Write JSON and text outputs to the Current Working Directory (CWD)
+fn write_outputs(found: &[Browser]) -> std::io::Result<()> {
+    // 1. JSON output (browsers.json)
+    let json_path = PathBuf::from("browsers.json");
+    let json = serde_json::to_string_pretty(found).unwrap_or_else(|_| "[]".to_string());
+    fs::write(&json_path, json)?;
+    println!("📄 Saved full browser list to {}", json_path.display());
+
+
+    // 2. Text output (browsers.txt)
+    let text_path = PathBuf::from("browsers.txt");
+    let mut content = String::new();
+    for b in found {
+        content.push_str(&format!("{} = {}\n", b.name, b.path.display()));
+    }
+    fs::write(&text_path, content)?;
+    println!("📄 Saved full browser list to {}", text_path.display());
+
+    Ok(())
 }

--- a/commands/links.rs
+++ b/commands/links.rs
@@ -1,9 +1,13 @@
+// commands/links.rs
 use std::collections::HashMap;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{PathBuf, Path};
 use serde::{Serialize, Deserialize};
 use std::process::Command;
 use crate::commands::detect::Browser;
+use std::io;
+
+// --- Data Structures ---
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Link {
@@ -16,22 +20,42 @@ pub struct LinkConfig {
     pub links: Vec<Link>,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum LaunchMode {
+    Normal,
+    Private,
+}
+
+// --- LinkConfig Implementation ---
+
 impl LinkConfig {
-    pub fn load(path: &PathBuf) -> Self {
+    pub fn load(path: &Path) -> Self {
         if path.exists() {
-            let data = fs::read_to_string(path).unwrap_or_default();
-            serde_json::from_str(&data).unwrap_or(LinkConfig { links: vec![] })
+            match fs::read_to_string(path) {
+                Ok(data) => serde_json::from_str(&data).unwrap_or_else(|e| {
+                    eprintln!("⚠️ Failed to parse link config {}: {}", path.display(), e);
+                    LinkConfig { links: vec![] }
+                }),
+                Err(e) => {
+                    eprintln!("⚠️ Failed to read link config {}: {}", path.display(), e);
+                    LinkConfig { links: vec![] }
+                }
+            }
         } else {
             LinkConfig { links: vec![] }
         }
     }
 
-    pub fn save(&self, path: &PathBuf) {
-        let json = serde_json::to_string_pretty(&self).unwrap();
-        fs::write(path, json).unwrap();
+    pub fn save(&self, path: &Path) -> io::Result<()> {
+        let json = serde_json::to_string_pretty(&self)?;
+        fs::write(path, json)
     }
 
     pub fn add_link(&mut self, tag: String, url: String) {
+        if self.links.iter().any(|l| l.tag == tag) {
+            println!("Replacing existing link for tag: {}", tag);
+            self.links.retain(|l| l.tag != tag);
+        }
         self.links.push(Link { tag, url });
     }
 
@@ -43,31 +67,13 @@ impl LinkConfig {
         if self.links.is_empty() {
             println!("⚠️ No links saved.");
         } else {
-            println!("📄 Saved links:");
+            println!("\n📄 Saved links:");
             for l in &self.links {
                 println!("  [{}] {}", l.tag, l.url);
             }
         }
     }
-}
 
-/// Launch URL in the selected browser
-pub fn launch_link(browser: &Browser, url: &str) {
-    println!("🚀 Launching {} in {}", url, browser.path.display());
-    if cfg!(target_os = "windows") {
-        Command::new(&browser.path)
-            .arg(url)
-            .spawn()
-            .expect("Failed to open browser");
-    } else {
-        Command::new(&browser.path)
-            .arg(url)
-            .spawn()
-            .expect("Failed to open browser");
-    }
-}
-
-impl LinkConfig {
     pub fn remove_link(&mut self, tag: &str) -> bool {
         if let Some(pos) = self.links.iter().position(|l| l.tag == tag) {
             self.links.remove(pos);
@@ -77,9 +83,92 @@ impl LinkConfig {
         }
     }
 
-    pub fn open_all(&self, browser: &Browser) {
-        for l in &self.links {
-            super::links::launch_link(browser, &l.url);
+    pub fn open_all(&self, browser: &Browser, mode: LaunchMode) {
+        if self.links.is_empty() {
+            println!("⚠️ No links to open.");
+            return;
         }
+        
+        // Collect URLs to launch simultaneously (better UX than sequential spawning)
+        let urls: Vec<&str> = self.links.iter().map(|l| l.url.as_str()).collect();
+        launch_urls_simultaneously(browser, &urls, mode);
+    }
+}
+
+// --- Launch Logic ---
+
+/// Determines the correct private mode flags based on the browser executable name.
+fn get_private_flags(browser_path: &Path) -> &'static [&'static str] {
+    let exe_lower = browser_path.file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_lowercase();
+
+    if exe_lower.contains("firefox") {
+        &["-private-window"]
+    } else if exe_lower.contains("msedge") {
+        &["--inprivate"]
+    } else if exe_lower.contains("brave") || exe_lower.contains("chrome") || exe_lower.contains("chromium") || exe_lower.contains("vivaldi") {
+        // Default for Chromium family
+        &["--incognito"]
+    } else if exe_lower.contains("safari") {
+        // Safari must be handled differently, usually via AppleScript, but since we are using
+        // direct Command::new(), we might skip specific private mode for Safari on macOS
+        // or rely on a user profile method, which is complex. Sticking to common flags.
+        &[] 
+    } else {
+        &[] // Unknown browser or standard launch
+    }
+}
+
+
+/// Launch a single URL in the selected browser
+pub fn launch_link(browser: &Browser, url: &str, mode: LaunchMode) {
+    let mode_str = match mode {
+        LaunchMode::Normal => "Normal Mode",
+        LaunchMode::Private => "Private Mode",
+    };
+    println!("🚀 Launching {} in {} ({})", url, browser.path.display(), mode_str);
+
+    let mut command = Command::new(&browser.path);
+    
+    if let LaunchMode::Private = mode {
+        let flags = get_private_flags(&browser.path);
+        if flags.is_empty() {
+            println!("⚠️ Warning: Private mode flags unknown for this browser. Launching normally.");
+        } else {
+            command.args(flags);
+        }
+    }
+
+    if let Err(e) = command.arg(url).spawn() {
+        eprintln!("⚠️ Failed to launch browser {}: {}", browser.path.display(), e);
+    }
+}
+
+/// Launch multiple URLs in the selected browser instance.
+pub fn launch_urls_simultaneously(browser: &Browser, urls: &[&str], mode: LaunchMode) {
+    let mode_str = match mode {
+        LaunchMode::Normal => "Normal Mode",
+        LaunchMode::Private => "Private Mode",
+    };
+    println!("🚀 Launching {} link(s) in {} ({})", urls.len(), browser.path.display(), mode_str);
+
+    let mut command = Command::new(&browser.path);
+
+    if let LaunchMode::Private = mode {
+        let flags = get_private_flags(&browser.path);
+        if flags.is_empty() {
+            println!("⚠️ Warning: Private mode flags unknown for this browser. Launching normally.");
+        } else {
+            command.args(flags);
+        }
+    }
+
+    // Add all URLs as arguments
+    command.args(urls);
+
+    if let Err(e) = command.spawn() {
+        eprintln!("⚠️ Failed to launch browser {}: {}", browser.path.display(), e);
     }
 }

--- a/commands/mod.rs
+++ b/commands/mod.rs
@@ -1,6 +1,6 @@
 pub mod detect;
-pub mod add;
-pub mod list;
-pub mod launch;
+//pub mod add;
+//pub mod list;
+//pub mod launch;
 pub mod links;
 pub mod aliases;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,95 +1,168 @@
 mod commands;
 
-use crate::commands::links::{self, LinkConfig};
+use crate::commands::links::{LinkConfig, launch_link, LaunchMode};
 use crate::commands::aliases::AliasConfig;
-use crate::commands::detect::{Browser, run as detect_browsers};
+use crate::commands::detect::{run as detect_browsers, Browser};
 
-use std::path::PathBuf;
+use std::path::{PathBuf, Path};
 use std::env;
+use clap::{Parser, Subcommand, CommandFactory}; // <-- ADDED CommandFactory
 
-fn main() { let args: Vec<String> = env::args().collect(); 
-    if args.len() < 2 { print_help(); return; } 
-    // Detect or load browser
-     let browser = detect_browsers().expect("No browser available");
-   //Config paths
-    let home = env::var("HOME").unwrap_or(".".to_string());
-     let link_path = PathBuf::from(format!("{}/.quick_tabs_links.json", home));
-      let alias_path = PathBuf::from(format!("{}/.quick_tabs_aliases.json", home)); 
-      let mut link_cfg = LinkConfig::load(&link_path);
- let mut alias_cfg = AliasConfig::load(&alias_path);
+// --- CLI Structure using Clap ---
 
-let mut link_cfg = LinkConfig::load(&link_path);
-    let mut alias_cfg = AliasConfig::load(&alias_path);
-
-    match args[1].as_str() {
-    "launch" => {
-        if args.len() < 3 {
-            println!("⚠️ Please provide a tag or URL to launch");
-            return;
-        }
-        let target = &args[2];
-        let url = alias_cfg.resolve(target)
-            .or_else(|| link_cfg.get_url(target))
-            .unwrap_or_else(|| target.to_string());
-        links::launch_link(&browser, &url);
-    },
-    "add-link" => {
-        if args.len() < 4 {
-            println!("⚠️ Usage: add-link <tag> <url>");
-            return;
-        }
-        link_cfg.add_link(args[2].clone(), args[3].clone());
-        link_cfg.save(&link_path);
-        println!("✅ Link saved!");
-    },
-    "add-alias" => {
-        if args.len() < 4 {
-            println!("⚠️ Usage: add-alias <tag> <url>");
-            return;
-        }
-        alias_cfg.add_alias(args[2].clone(), args[3].clone());
-        alias_cfg.save(&alias_path);
-        println!("✅ Alias saved!");
-    },
-    "remove-link" => {
-        if args.len() < 3 {
-            println!("⚠️ Usage: remove-link <tag>");
-            return;
-        }
-        if link_cfg.remove_link(&args[2]) {
-            link_cfg.save(&link_path);
-            println!("✅ Link removed!");
-        } else {
-            println!("⚠️ Link not found.");
-        }
-    },
-    "remove-alias" => {
-        if args.len() < 3 {
-            println!("⚠️ Usage: remove-alias <tag>");
-            return;
-        }
-        if alias_cfg.remove_alias(&args[2]) {
-            alias_cfg.save(&alias_path);
-            println!("✅ Alias removed!");
-        } else {
-            println!("⚠️ Alias not found.");
-        }
-    },
-    "list-links" => link_cfg.list(),
-    "open-all-links" => link_cfg.open_all(&browser),
-    "open-all-aliases" => alias_cfg.open_all(&browser),
-    _ => print_help(),
-}
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Cli {
+    #[clap(subcommand)]
+    command: Commands,
 }
 
-fn print_help() {
-    println!("Quick Tabs CLI - commands:");
-    println!("  launch <tag|url>         Launch a link in the detected browser");
-    println!("  add-link <tag> <url>     Add a link with a tag");
-    println!("  add-alias <tag> <url>    Add a shortcut/alias");
-    println!("  remove-link <tag>        Remove a saved link");
-    println!("  remove-alias <tag>       Remove a saved alias");
-    println!("  list-links               List saved links");
-    println!("  open-all-links           Open all saved links");
-    println!("  open-all-aliases         Open all aliases");
+#[derive(Subcommand, Debug)]
+enum Commands {
+    /// Launch a tag or URL in the detected browser
+    Launch {
+        target: String,
+        /// Open the link in incognito/private mode
+        #[arg(short, long)]
+        incognito: bool,
+    },
+    /// Add a new link tag
+    AddLink {
+        tag: String,
+        url: String,
+    },
+    /// Add a new alias shortcut
+    AddAlias {
+        tag: String,
+        url: String,
+    },
+    /// Remove a saved link
+    RemoveLink {
+        tag: String,
+    },
+    /// Remove a saved alias
+    RemoveAlias {
+        tag: String,
+    },
+    /// List saved links and aliases
+    ListLinks,
+    /// Open all saved links (can use --incognito)
+    OpenAllLinks {
+        /// Open links in incognito/private mode
+        #[arg(short, long)]
+        incognito: bool,
+    },
+    /// Open all saved aliases (can use --incognito)
+    OpenAllAliases {
+        /// Open aliases in incognito/private mode
+        #[arg(short, long)]
+        incognito: bool,
+    },
+    /// Re-detect and select the preferred browser
+    Detect,
+    /// Print help information
+    Help,
+}
+
+// --- Main Execution ---
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Cli::parse();
+    
+    // 1. Config paths setup
+    let home = env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    let link_path = PathBuf::from(format!("{}/.quick_tabs_links.json", home));
+    let alias_path = PathBuf::from(format!("{}/.quick_tabs_aliases.json", home));
+    
+    // 2. Browser Detection (only required for launch/open commands)
+    let browser_result = detect_browsers();
+
+    match cli.command {
+        // --- Commands requiring Config & Browser ---
+        Commands::Launch { target, incognito } => {
+            let browser = get_browser_or_exit(browser_result)?;
+            let link_cfg = LinkConfig::load(&link_path);
+            let alias_cfg = AliasConfig::load(&alias_path);
+            
+            let mode = if incognito { LaunchMode::Private } else { LaunchMode::Normal };
+
+            let url = alias_cfg.resolve(&target)
+                .or_else(|| link_cfg.get_url(&target))
+                .unwrap_or_else(|| target);
+
+            launch_link(&browser, &url, mode);
+        },
+
+        // --- Commands requiring Config only ---
+        Commands::AddLink { tag, url } => {
+            let mut link_cfg = LinkConfig::load(&link_path);
+            link_cfg.add_link(tag, url);
+            link_cfg.save(&link_path)?;
+            println!("✅ Link saved!");
+        },
+        Commands::AddAlias { tag, url } => {
+            let mut alias_cfg = AliasConfig::load(&alias_path);
+            alias_cfg.add_alias(tag, url);
+            alias_cfg.save(&alias_path)?;
+            println!("✅ Alias saved!");
+        },
+        Commands::RemoveLink { tag } => {
+            let mut link_cfg = LinkConfig::load(&link_path);
+            if link_cfg.remove_link(&tag) {
+                link_cfg.save(&link_path)?;
+                println!("✅ Link removed!");
+            } else {
+                println!("⚠️ Link tag '{}' not found.", tag);
+            }
+        },
+        Commands::RemoveAlias { tag } => {
+            let mut alias_cfg = AliasConfig::load(&alias_path);
+            if alias_cfg.remove_alias(&tag) {
+                alias_cfg.save(&alias_path)?;
+                println!("✅ Alias removed!");
+            } else {
+                println!("⚠️ Alias tag '{}' not found.", tag);
+            }
+        },
+        Commands::ListLinks => {
+            LinkConfig::load(&link_path).list();
+            AliasConfig::load(&alias_path).list();
+        },
+        
+        // --- Commands requiring Config & Browser, and Incognito flag ---
+        Commands::OpenAllLinks { incognito } => {
+            let browser = get_browser_or_exit(browser_result)?;
+            let link_cfg = LinkConfig::load(&link_path);
+            let mode = if incognito { LaunchMode::Private } else { LaunchMode::Normal };
+            link_cfg.open_all(&browser, mode);
+        },
+        Commands::OpenAllAliases { incognito } => {
+            let browser = get_browser_or_exit(browser_result)?;
+            let alias_cfg = AliasConfig::load(&alias_path);
+            let mode = if incognito { LaunchMode::Private } else { LaunchMode::Normal };
+            alias_cfg.open_all(&browser, mode);
+        },
+
+        // --- Browser Commands ---
+        Commands::Detect => {
+            // detect_browsers returns Option<Browser>, not Result. We ignore the return value.
+            let _ = detect_browsers(); 
+        },
+        Commands::Help => {
+            Cli::command().print_help()?;
+        }
+    }
+
+    Ok(())
+}
+
+fn get_browser_or_exit(browser_result: Option<Browser>) -> Result<Browser, Box<dyn std::error::Error>> {
+    match browser_result {
+        Some(b) => Ok(b),
+        None => {
+            eprintln!("❌ Error: No browser configured. Run 'quick_tabs detect' or set manually.");
+            // We use standard library exit here since we cannot proceed without a browser
+            std::process::exit(1); 
+        }
+    }
 }


### PR DESCRIPTION
- Added more robust browser detection for Windows, and this now uses clap for CLI argument parsing.

- Fixed the issue where the browser wasn’t opening in a private window, even when specified via CLI arguments.

- Added help support for the CLI, as it was missing before.